### PR TITLE
Use wiremock for SQS testing.

### DIFF
--- a/src/test/resources/json/file_event_expected_response.json
+++ b/src/test/resources/json/file_event_expected_response.json
@@ -1,0 +1,5 @@
+{
+  "filePropertyName": "SHA256ServerSideChecksum",
+  "fileId": "acea5919-25a3-4c6b-8908-fa47cc77878f",
+  "value": "9e994cad5c56b82e10bd9012e98992027631cd36daef4739613c5dd68b7d7f0e"
+}

--- a/src/test/resources/json/large_file_event_expected_response.json
+++ b/src/test/resources/json/large_file_event_expected_response.json
@@ -1,0 +1,5 @@
+{
+  "filePropertyName": "SHA256ServerSideChecksum",
+  "fileId": "acea5919-25a3-4c6b-8908-fa47cc77878f",
+  "value": "c08c59a10f61526ae02808f761d2fd75c09cb2d77d608dc01fdbc35e3fdaf11d"
+}

--- a/src/test/scala/uk/gov/nationalarchives/checksum/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/checksum/LambdaTest.scala
@@ -5,92 +5,84 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import uk.gov.nationalarchives.checksum.utils.TestUtils._
-import io.circe.parser.decode
-import graphql.codegen.AddFileMetadata.addFileMetadata.AddFileMetadata
 
 import scala.util.Try
 
-class LambdaTest extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterEach  {
+class LambdaTest extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterEach {
 
   override def beforeAll(): Unit = {
-    sqsApi.start()
-    outputQueueHelper.createQueue
-    inputQueueHelper.createQueue
     wiremockKmsEndpoint.start()
     wiremockKmsEndpoint.stubFor(post(urlEqualTo("/")))
+    wiremockSqsEndpoint.start()
   }
 
   override def afterAll(): Unit = {
     wiremockKmsEndpoint.stop()
+    wiremockSqsEndpoint.stop()
   }
 
   override def beforeEach(): Unit = {
-    outputQueueHelper.receive.foreach(outputQueueHelper.delete)
-    inputQueueHelper.receive.foreach(inputQueueHelper.delete)
+    wiremockSqsEndpoint.resetRequests()
   }
 
   "The update method" should "put a message in the output queue if the message is successful " in {
+    stubSendMessage()
     new Lambda().process(createEvent("sqs_file_event"), null)
-    val msgs = outputQueueHelper.receive
+    val msgs = getEventsForFilters(("QueueUrl", outputQueue), ("Action", "SendMessage"))
     msgs.size should equal(1)
   }
 
   "The update method" should "put one message in the output queue, delete the successful message and leave the key error message" in {
+    stubSendMessage()
+    stubDeleteMessage()
     Try(new Lambda().process(createEvent("sqs_file_event", "sqs_file_no_key"), null))
-    val outputMessages = outputQueueHelper.receive
-    val inputMessages = inputQueueHelper.receive
-    outputMessages.size should equal(1)
-    inputMessages.size should equal(1)
+    outputSentMessageCount should equal(1)
+    inputDeleteMessageCount should equal(1)
   }
 
-  "The update method" should "put one message in the output queue, delete the successful message and leave the decoding error message" in {
-    Try(new Lambda().process(createEvent("sqs_file_event", "sqs_file_invalid_json"), null))
-    val outputMessages = outputQueueHelper.receive
-    val inputMessages = inputQueueHelper.receive
-    outputMessages.size should equal(1)
-    inputMessages.size should equal(1)
-  }
-
-  "The update method" should "leave the queues unchanged if there are no successful messages" in {
-    Try(new Lambda().process(createEvent("sqs_file_invalid_json"), null))
-    val outputMessages = outputQueueHelper.receive
-    val inputMessages = inputQueueHelper.receive
-    outputMessages.size should equal(0)
-    inputMessages.size should equal(1)
-  }
-
-  "The update method" should "return the receipt handle for a successful message" in {
-    val event = createEvent("sqs_file_event")
-    val response = new Lambda().process(event, null)
-    response.head should equal(receiptHandle(event.getRecords.get(0).getBody))
-  }
-
-  "The update method" should "throw an exception for a no key error" in {
-    val event = createEvent("sqs_file_no_key")
-    val exception = intercept[RuntimeException] {
-      new Lambda().process(event, null)
+    "The update method" should "put one message in the output queue, delete the successful message and leave the decoding error message" in {
+      stubSendMessage()
+      stubDeleteMessage()
+      Try(new Lambda().process(createEvent("sqs_file_event", "sqs_file_invalid_json"), null))
+      outputSentMessageCount should equal(1)
+      inputDeleteMessageCount should equal(1)
     }
-    exception.getMessage should equal("java.io.FileNotFoundException: ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/no_file (No such file or directory)")
-  }
 
-  "The update method" should "calculate the correct checksum for a file with one chunk" in {
-    new Lambda().process(createEvent("sqs_file_event"), null)
-    val msgs = outputQueueHelper.receive
-    val metadata: AddFileMetadata = decode[AddFileMetadata](msgs.head.body) match {
-      case Right(metadata) => metadata
-      case Left(error) => throw error
+    "The update method" should "leave the queues unchanged if there are no successful messages" in {
+      Try(new Lambda().process(createEvent("sqs_file_invalid_json"), null))
+      outputSentMessageCount should equal(0)
+      inputDeleteMessageCount should equal(0)
     }
-    metadata.value should equal("9e994cad5c56b82e10bd9012e98992027631cd36daef4739613c5dd68b7d7f0e")
-  }
 
-  "The update method" should "calculate the correct checksum for a file with two chunks" in {
-    new Lambda().process(createEvent("sqs_file_event_large_file"), null)
-    val msgs = outputQueueHelper.receive
-    val metadata: AddFileMetadata = decode[AddFileMetadata](msgs.head.body) match {
-      case Right(metadata) => metadata
-      case Left(error) => throw error
+    "The update method" should "return the receipt handle for a successful message" in {
+      stubSendMessage()
+      val event = createEvent("sqs_file_event")
+      val response = new Lambda().process(event, null)
+      response.head should equal(receiptHandle(event.getRecords.get(0).getBody))
     }
-    metadata.value should equal("c08c59a10f61526ae02808f761d2fd75c09cb2d77d608dc01fdbc35e3fdaf11d")
-  }
+
+    "The update method" should "throw an exception for a no key error" in {
+      val event = createEvent("sqs_file_no_key")
+      val exception = intercept[RuntimeException] {
+        new Lambda().process(event, null)
+      }
+      exception.getMessage should equal("java.io.FileNotFoundException: ./src/test/resources/testfiles/f0a73877-6057-4bbb-a1eb-7c7b73cab586/no_file (No such file or directory)")
+    }
+
+    "The update method" should "calculate the correct checksum for a file with one chunk" in {
+      stubSendMessage()
+      new Lambda().process(createEvent("sqs_file_event"), null)
+      val expectedResponse = urlEncodeFile("file_event_expected_response")
+      val outputQueueMessages = getEventsForFilters(("QueueUrl", outputQueue), ("Action", "SendMessage"), ("MessageBody", expectedResponse))
+      outputQueueMessages.size should equal(1)
+    }
+
+    "The update method" should "calculate the correct checksum for a file with two chunks" in {
+      stubSendMessage("dbb12b25d77563d8c8eb9191eae71511")
+      new Lambda().process(createEvent("sqs_file_event_large_file"), null)
+      val expectedResponse = urlEncodeFile("large_file_event_expected_response")
+      val outputQueueMessages = getEventsForFilters(("QueueUrl", outputQueue), ("Action", "SendMessage"), ("MessageBody", expectedResponse))
+      outputQueueMessages.size should equal(1)
+    }
 
 }

--- a/src/test/scala/uk/gov/nationalarchives/checksum/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/checksum/utils/TestUtils.scala
@@ -27,7 +27,7 @@ object TestUtils {
   def receiptHandle(body: String): String = Base64.getEncoder.encodeToString(body.getBytes("UTF-8"))
 
   def urlEncodeFile(location: String): String = URLEncoder.encode(
-    fromResource(s"json/$location.json").filterNot(_.isWhitespace).mkString, Charset.defaultCharset()
+    fromResource(s"json/$location.json").filterNot(_.isWhitespace).mkString, "UTF-8"
   )
 
   def createEvent(locations: String*): SQSEvent = {
@@ -49,8 +49,8 @@ object TestUtils {
 
   def url(queueName: String) = s"http://localhost:8002/1/test_${queueName}_queue"
 
-  val outputQueue: String = URLEncoder.encode(url("output"), Charset.defaultCharset())
-  val inputQueue: String = URLEncoder.encode(url("input"), Charset.defaultCharset())
+  val outputQueue: String = URLEncoder.encode(url("output"), "UTF-8")
+  val inputQueue: String = URLEncoder.encode(url("input"), "UTF-8")
 
   def sendMessageXml(md5: String): Elem =
     <SendMessageResponse>
@@ -79,7 +79,7 @@ object TestUtils {
       decode[KMSRequest](request.getBodyAsString) match {
         case Left(err) => throw err
         case Right(req) =>
-          val charset = Charset.defaultCharset()
+          val charset = "UTF-8"
           val plainText = charset.newDecoder.decode(ByteBuffer.wrap(req.CiphertextBlob.getBytes(charset))).toString
           ResponseDefinitionBuilder
             .like(responseDefinition)

--- a/src/test/scala/uk/gov/nationalarchives/checksum/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/checksum/utils/TestUtils.scala
@@ -1,30 +1,34 @@
 package uk.gov.nationalarchives.checksum.utils
 
-import java.net.URI
-import java.util.Base64
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.client.WireMock.{okXml, post, urlEqualTo}
 import com.github.tomakehurst.wiremock.common.FileSource
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.extension.{Parameters, ResponseDefinitionTransformer}
 import com.github.tomakehurst.wiremock.http.{Request, ResponseDefinition}
-import io.findify.sqsmock.SQSService
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.sqs.SqsClient
-import software.amazon.awssdk.services.sqs.model._
-
-import java.nio.ByteBuffer
-import java.nio.charset.Charset
-import scala.io.Source.fromResource
-import scala.jdk.CollectionConverters._
+import com.github.tomakehurst.wiremock.matching.ContainsPattern
+import com.github.tomakehurst.wiremock.stubbing.{ServeEvent, StubMapping}
 import io.circe.generic.auto._
 import io.circe.parser.decode
+
+import java.net.URLEncoder
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.util.Base64
+import scala.io.Source.fromResource
+import scala.jdk.CollectionConverters._
+import scala.xml.Elem
 
 object TestUtils {
 
   def receiptHandle(body: String): String = Base64.getEncoder.encodeToString(body.getBytes("UTF-8"))
+
+  def urlEncodeFile(location: String): String = URLEncoder.encode(
+    fromResource(s"json/$location.json").filterNot(_.isWhitespace).mkString, Charset.defaultCharset()
+  )
 
   def createEvent(locations: String*): SQSEvent = {
     val event = new SQSEvent()
@@ -33,7 +37,6 @@ object TestUtils {
       val record = new SQSMessage()
       val body = fromResource(s"json/$location.json").mkString
       record.setBody(body)
-      inputQueueHelper.send(body)
       record.setReceiptHandle(receiptHandle(body))
       record
     })
@@ -42,37 +45,33 @@ object TestUtils {
     event
   }
 
-  case class QueueHelper(queueUrl: String) {
-    val sqsClient: SqsClient = SqsClient.builder()
-      .region(Region.EU_WEST_2)
-      .endpointOverride(URI.create("http://localhost:8002"))
-      .build()
-
-    def send(body: String): SendMessageResponse = sqsClient.sendMessage(SendMessageRequest
-      .builder.messageBody(body).queueUrl(queueUrl).build())
-
-    def receive: List[Message] = sqsClient.receiveMessage(ReceiveMessageRequest
-      .builder
-      .maxNumberOfMessages(10)
-      .queueUrl(queueUrl)
-      .build).messages.asScala.toList
-
-    def createQueue: CreateQueueResponse = sqsClient.createQueue(CreateQueueRequest.builder.queueName(queueUrl.split("/")(4)).build())
-
-    def delete(msg: Message): DeleteMessageResponse = sqsClient.deleteMessage(DeleteMessageRequest
-      .builder.queueUrl(queueUrl).receiptHandle(msg.receiptHandle()).build)
-  }
-
   val port = 8002
-  val account = 1
-  val inputQueueName = "test_input_queue"
-  val outputQueueName = "test_output_queue"
-  val sqsApi = new SQSService(port)
-  val inputQueueUrl = s"http://localhost:$port/$account/$inputQueueName"
-  val outputQueueUrl = s"http://localhost:$port/$account/$outputQueueName"
 
-  val inputQueueHelper: QueueHelper = QueueHelper(inputQueueUrl)
-  val outputQueueHelper: QueueHelper = QueueHelper(outputQueueUrl)
+  def url(queueName: String) = s"http://localhost:8002/1/test_${queueName}_queue"
+
+  val outputQueue: String = URLEncoder.encode(url("output"), Charset.defaultCharset())
+  val inputQueue: String = URLEncoder.encode(url("input"), Charset.defaultCharset())
+
+  def sendMessageXml(md5: String): Elem =
+    <SendMessageResponse>
+      <SendMessageResult>
+        <MD5OfMessageBody>{md5}</MD5OfMessageBody>
+        <MD5OfMessageAttributes>3ae8f24a165a8cedc005670c81a27295</MD5OfMessageAttributes>
+        <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+      </SendMessageResult>
+      <ResponseMetadata>
+        <RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId>
+      </ResponseMetadata>
+    </SendMessageResponse>
+
+  val deleteMessageXml: Elem =
+    <DeleteMessageResponse>
+      <ResponseMetadata>
+        <RequestId>b5293cb5-d306-4a17-9048-b263635abe42</RequestId>
+      </ResponseMetadata>
+    </DeleteMessageResponse>
+
+  val wiremockSqsEndpoint = new WireMockServer(new WireMockConfiguration().port(port))
 
   val wiremockKmsEndpoint = new WireMockServer(new WireMockConfiguration().port(9003).extensions(new ResponseDefinitionTransformer {
     override def transform(request: Request, responseDefinition: ResponseDefinition, files: FileSource, parameters: Parameters): ResponseDefinition = {
@@ -90,4 +89,30 @@ object TestUtils {
     }
     override def getName: String = ""
   }))
+
+  def stubSendMessage(md5Sum: String = "7fa99856b45866889512524430db4208"): StubMapping =
+    wiremockSqsEndpoint.stubFor(post(urlEqualTo("/"))
+      .withRequestBody(new ContainsPattern("SendMessage"))
+      .willReturn(okXml(sendMessageXml(md5Sum).toString())))
+
+  def stubDeleteMessage(): StubMapping =
+    wiremockSqsEndpoint.stubFor(post(urlEqualTo("/"))
+      .withRequestBody(new ContainsPattern("DeleteMessage"))
+      .willReturn(okXml(deleteMessageXml.toString())))
+
+
+  def getEventsForFilters(filterParams: (String, String)*): List[ServeEvent] =
+    wiremockSqsEndpoint.getAllServeEvents.asScala.toList.filter(event => {
+      val bodyParams: Map[String, String] = event.getRequest.getBodyAsString.split("&").map(param => {
+        val params = param.split("=")
+        (params(0), params(1))
+      }).toMap
+
+      filterParams.map(filterParam =>
+        bodyParams.get(filterParam._1).contains(filterParam._2)
+      ).forall(p => p)
+    })
+
+  def outputSentMessageCount: Int = getEventsForFilters(("QueueUrl", outputQueue), ("Action", "SendMessage")).size
+  def inputDeleteMessageCount: Int = getEventsForFilters(("QueueUrl", outputQueue), ("Action", "SendMessage")).size
 }

--- a/src/test/scala/uk/gov/nationalarchives/checksum/utils/TestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/checksum/utils/TestUtils.scala
@@ -79,7 +79,7 @@ object TestUtils {
       decode[KMSRequest](request.getBodyAsString) match {
         case Left(err) => throw err
         case Right(req) =>
-          val charset = "UTF-8"
+          val charset = Charset.defaultCharset()
           val plainText = charset.newDecoder.decode(ByteBuffer.wrap(req.CiphertextBlob.getBytes(charset))).toString
           ResponseDefinitionBuilder
             .like(responseDefinition)


### PR DESCRIPTION
This will allows us to check if an API call to SQS has been made which
could be useful for testing the change visibility timeout changes.

Also, this may be better because we're not relying on any extra third
party libraries as we were already using WireMock for KMS calls.
