### PR TITLE
Set visibility timeout on error.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   lazy val circeCore = "io.circe" %% "circe-core" % "0.13.0"
   lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.13.0"
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.13.0"
-  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.15"
+  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.16"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "2.2.0"
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"

--- a/src/test/scala/uk/gov/nationalarchives/checksum/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/checksum/LambdaTest.scala
@@ -54,7 +54,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterE
 
   "The update method" should "leave the queues unchanged if there are no successful messages" in {
     Try(new Lambda().process(createEvent("sqs_file_invalid_json"), null))
-    outputQueueHelper.nonVisibleMessageCount should equal(0)
+    outputQueueHelper.receive.size should equal(0)
     inputQueueHelper.nonVisibleMessageCount should equal(1)
   }
 
@@ -99,7 +99,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterAll with BeforeAndAfterE
     inputQueueHelper.nonVisibleMessageCount should equal(1)
   }
 
-  "The update method" should "leave an file not found message in the input queue in a visible state" in {
+  "The update method" should "make the message immediately available for retry" in {
     Try(new Lambda().process(createEvent("sqs_file_no_key"), null))
     inputQueueHelper.receive.size should equal(1)
   }


### PR DESCRIPTION
This uses the IO method handleErrorWith. It relies on having valid
decoded json so it can use the receipt handle to change the message
visibility so if there is a failure decoding the json, the visibility
timeout isn't changed but there's not much we can do about that.

I've added a couple of tests to check that the two error types set the
timeout correctly. They're technically being tested further up but I've
added them in so the description states explicitly what's happening.
