### PR TITLE
Fix upgrade to cats-effect3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: TDR Run Lambda Tests
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches-ignore:
       - master

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val circeGeneric = "io.circe" %% "circe-generic" % "0.14.1"
   lazy val circeParser = "io.circe" %% "circe-parser" % "0.14.1"
   lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.16"
-  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.3.8"
+  lazy val catsEffect = "org.typelevel" %% "cats-effect" % "2.5.4"
   lazy val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
   lazy val logback = "ch.qos.logback" % "logback-classic" % "1.2.11"
   lazy val logstashLogbackEncoder = "net.logstash.logback" % "logstash-logback-encoder" % "7.0.1"


### PR DESCRIPTION
There's a dependency in the AWS utils that stops this working.

I've also removed the pull_request_target trigger as we're not using
that any more.
